### PR TITLE
Add sublime_text version selectors

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4,15 +4,13 @@
     {
       "name": "Language - French - Français",
       "details": "https://github.com/superbob/SublimeTextLanguageFrench",
-      "homepage": "https://github.com/superbob/SublimeTextLanguageFrench",
-      "readme": "https://raw.github.com/superbob/SublimeTextLanguageFrench/master/README.md",
       "labels": ["spell check", "dictionnary", "french"],
       "releases": [
         {
+          "sublime_text": "*",
           "details": "https://github.com/superbob/SublimeTextLanguageFrench/tags"
         }
       ]
     }
-
   ]
 }


### PR DESCRIPTION
We require these now due to the confusion it caused in the past

Also removed redundant information because Package Control defaults to these anyway
